### PR TITLE
Fix edit links and post-save redirect to use identifier instead of _id

### DIFF
--- a/src/main/webapp/WEB-INF/templates/dataset-detail.html
+++ b/src/main/webapp/WEB-INF/templates/dataset-detail.html
@@ -1,6 +1,6 @@
 <div align="left" class="row">
     <div class="col-md-10">
-        <h1>{{dataset.title}} <a v-bind:href="'/edit-dataset/' + dataset._id" class="edit-link">(Edit)</a></h1>
+        <h1>{{dataset.title}} <a v-bind:href="'/edit-dataset/' + dataset.identifier" class="edit-link">(Edit)</a></h1>
     </div>
     <div class="col-md-2 stars">
         <img v-bind:src="star_img(dataset)" v-bind:title="star_explain(dataset)" id="stars_img"/>

--- a/src/main/webapp/WEB-INF/templates/dataset-edit.js
+++ b/src/main/webapp/WEB-INF/templates/dataset-edit.js
@@ -42,7 +42,7 @@ var app = new Vue({
                 //alert(JSON.stringify(response));
 				// redirect to 
 				// 		"'/edit-dataset/' + dataset._id" 
-				window.location.href = '/dataset/' + dataset._id;
+				window.location.href = '/dataset/' + dataset.identifier;
 
             }, function (response) {
                 console.log(JSON.stringify(response))

--- a/src/main/webapp/WEB-INF/templates/dataset-list.html
+++ b/src/main/webapp/WEB-INF/templates/dataset-list.html
@@ -61,7 +61,7 @@
                         <td>{{dataset._id}}</td>
                         <td>
                             <p data-placement="top" data-toggle="tooltip" v-bind:title="'Click to Open ' + dataset.title">
-                                <a class="btn btn-info btn-xs" v-bind:href="'/dataset/' + dataset._id" 
+                                <a class="btn btn-info btn-xs" v-bind:href="'/dataset/' + dataset._id"
                                         data-title="Edit" data-toggle="modal" data-target="#edit" >
                                     <span class="glyphicon glyphicon-search"></span>
                                 </a>
@@ -69,7 +69,7 @@
                         </td>
                         <td>
                             <p data-placement="top" data-toggle="tooltip" v-bind:title="'Click to Open '+dataset.title">
-                                <a class="btn btn-primary btn-xs" v-bind:href="'/edit-dataset/' + dataset._id" 
+                                <a class="btn btn-primary btn-xs" v-bind:href="'/edit-dataset/' + dataset._id"
                                         data-title="Edit" data-toggle="modal" data-target="#edit" >
                                     <span class="glyphicon glyphicon-edit"></span>
                                 </a>


### PR DESCRIPTION
Fixes #83

Templates were constructing edit links and post-save redirects using `dataset._id` (the MongoDB internal id) instead of `dataset.identifier`, causing 404 errors for datasets where these values differ.

## Changes
- `dataset-detail.html`: Edit link now uses `dataset.identifier`
- `dataset-edit.js`: Post-save redirect now uses `dataset.identifier`